### PR TITLE
add postcss-load-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "defined": "^1.0.0",
     "postcss": "^5.1.2",
+    "postcss-load-config": "^1.0.0",
     "resolve": "^1.1.7",
     "xtend": "^4.0.1"
   }


### PR DESCRIPTION
The [`postcss-load-config` plugin](https://github.com/michael-ciniawsky/postcss-load-config) allows postcss config to be loaded from different locations.

There is an example of it in use in the [`postcss-loader`](https://github.com/postcss/postcss-loader) for webpack.

This is my first time playing around with browserify plugins. I'm happy to change the load/extend order of plugins/options. Let me know what you think 😃 