### PR TITLE
fix github repository URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ahdinosaur/sheetify-postcss.git"
+    "url": "git+https://github.com/stackcss/sheetify-postcss.git"
   },
   "keywords": [],
   "author": "Mikey <michael.williams@enspiral.com> (http://dinosaur.is)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ahdinosaur/sheetify-postcss/issues"
+    "url": "https://github.com/stackcss/sheetify-postcss/issues"
   },
-  "homepage": "https://github.com/ahdinosaur/sheetify-postcss#readme",
+  "homepage": "https://github.com/stackcss/sheetify-postcss#readme",
   "devDependencies": {
     "browserify": "^13.1.0",
     "dependency-check": "^2.6.0",


### PR DESCRIPTION
👋 hi, thanks for publishing this transform! the repository URL on the npm package page 404'd, but these should work :)

Thanks!