### PR TITLE
Respect postcssrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ add to your `package.json` `browserify.transform` field:
 }
 ```
 
+### using `.postcssrc`
+
+Options and plugins can be defined using a config file. Uses [postcss-load-config](https://github.com/michael-ciniawsky/postcss-load-config) which supports `postcss` field in `package.json`, an external JSON or YAML (`.postcssrc`) file as well as JS (`.postcssrc.js` and `postcss.config.js`) file format.
+
+```javascript
+// .postcssrc.js
+module.exports = function (ctx) {
+  var plugins = [require('postcss-color-function')]
+
+  if (ctx.env !== 'development') {
+    plugins.push(require('autoprefixer'))
+  }
+
+  return {
+    map: ctx.env === 'development' ? 'inline' : false
+    plugins: plugins
+  }
+}
+```
+
 ## license
 
 The Apache License

--- a/index.js
+++ b/index.js
@@ -31,15 +31,18 @@ function transform (filename, source, options, done) {
       browser: true,
       console: false
     }
-  }, options, {plugins: plugins})
+  }, options)
+
+  delete ctx.plugins
 
   postcssrc(ctx, basedir).then(compile, function () {
-    return compile(ctx)
+    return compile({options: ctx})
   }).then(function (result) {
     done(null, result.css)
   }, done)
 
   function compile (config) {
-    return postcss(config.plugins).process(source, extend(ctx, config))
+    return postcss(plugins.concat(config.plugins).filter(Boolean))
+      .process(source, config.options)
   }
 }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,6 @@ function transform (filename, source, options, done) {
   }, done)
 
   function compile (config) {
-    return postcss(config.plugins).process(source, config)
+    return postcss(config.plugins).process(source, extend(ctx, config))
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "defined": "^1.0.0",
     "postcss": "^5.1.2",
+    "postcss-load-config": "^1.2.0",
     "resolve": "^1.1.7",
     "xtend": "^4.0.1"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ test(function (t) {
     })
   })
 
-  t.test('module should respect postcssrc', function (t) {
+  t.test('module should respect postcssrc config file', function (t) {
     t.plan(2)
 
     sheetifyPostcss('test.css', '.rule {}', { basedir: path.join(__dirname, 'stubs') }, (err, css) => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const test = require('tape')
 const sheetifyPostcss = require('../')
 
@@ -17,6 +18,15 @@ test(function (t) {
     sheetifyPostcss('test.css', '.rule {}', { basedir: __dirname, plugins: [ [ './stubs/postcss-plugin', { has: true } ] ] }, (err, css) => {
       t.equal(err, null)
       t.equal(css, '.ok-with-options {}')
+    })
+  })
+
+  t.test('module should respect postcssrc', function (t) {
+    t.plan(2)
+
+    sheetifyPostcss('test.css', '.rule {}', { basedir: path.join(__dirname, 'stubs') }, (err, css) => {
+      t.equal(err, null)
+      t.equal(css, '.ok-with-postcssrc {}')
     })
   })
 })

--- a/test/stubs/.postcssrc.js
+++ b/test/stubs/.postcssrc.js
@@ -8,8 +8,6 @@ var plugin = postcss.plugin('postcss-plugin', function postcssPlugin () {
   }
 })
 
-module.exports = function (ctx) {
-  return Object.assign({}, ctx, {
-    plugins: [plugin]
-  })
+module.exports = {
+  plugins: [plugin]
 }

--- a/test/stubs/.postcssrc.js
+++ b/test/stubs/.postcssrc.js
@@ -1,0 +1,15 @@
+var postcss = require('postcss')
+
+var plugin = postcss.plugin('postcss-plugin', function postcssPlugin () {
+  return function (root, result) {
+    root.walkRules('.rule', rule => {
+      rule.replaceWith(postcss.rule({ selector: '.ok-with-postcssrc' }))
+    })
+  }
+})
+
+module.exports = function (ctx) {
+  return Object.assign({}, ctx, {
+    plugins: [plugin]
+  })
+}


### PR DESCRIPTION
Support for dynamically configuring postcss options and plugins. Uses [postcss-load-config](https://github.com/michael-ciniawsky/postcss-load-config) to try and read local `.postcssrc`-file.

Related to https://github.com/stackcss/sheetify/issues/119, though only when used with postcss.